### PR TITLE
change variable period from unsigned long to float

### DIFF
--- a/src/SAMDTimerInterrupt.h
+++ b/src/SAMDTimerInterrupt.h
@@ -160,7 +160,7 @@ class SAMDTimerInterrupt
     timerCallback  _callback;        // pointer to the callback function
     float           _frequency;       // Timer frequency
     
-    unsigned long   _period;
+    float   _period;
     int             _prescaler;
     int             _compareValue;
 
@@ -186,7 +186,7 @@ class SAMDTimerInterrupt
     // No params and duration now. To be addes in the future by adding similar functions here or to SAMD-hal-timer.c
     bool setFrequency(float frequency, timerCallback callback)
     {
-      _period = (unsigned long) (1000000.0f / frequency);
+      _period =  (1000000.0f / frequency);
       
       if (_timerNumber == TIMER_TC3)
       {    
@@ -300,7 +300,7 @@ class SAMDTimerInterrupt
     
     private:
     
-    void setPeriod_TIMER_TC3(unsigned long period)
+    void setPeriod_TIMER_TC3(float period)
     {
       uint32_t TC_CTRLA_PRESCALER_DIVN;
 
@@ -364,7 +364,7 @@ class SAMDTimerInterrupt
       TC3->COUNT16.CTRLA.reg |= TC_CTRLA_PRESCALER_DIVN;
       TC3_wait_for_sync();
 
-      _compareValue = (int)(TIMER_HZ / (_prescaler/((float)period / 1000000))) - 1;
+      _compareValue = (int)(TIMER_HZ / (_prescaler/(period / 1000000.0))) - 1;
 
       // Make sure the count is in a proportional position to where it was
       // to prevent any jitter or disconnect when changing the compare value.
@@ -455,7 +455,7 @@ class SAMDTimerInterrupt
     float           _frequency;       // Timer frequency
     //uint32_t        _timerCount;      // count to activate timer
     
-    unsigned long   _period;
+    float   _period;
     int             _prescaler;
     int             _compareValue;
 
@@ -485,7 +485,7 @@ class SAMDTimerInterrupt
     // No params and duration now. To be addes in the future by adding similar functions here or to SAMD-hal-timer.c
     bool setFrequency(float frequency, timerCallback callback)
     {
-      _period = (unsigned long) (1000000.0f / frequency);
+      _period =  (1000000.0f / frequency);
       
       TISR_LOGDEBUG3(F("_period ="), _period, F(", frequency ="), frequency);
       
@@ -656,7 +656,7 @@ class SAMDTimerInterrupt
     
     private:
     
-    void setPeriod_TIMER_TC3(unsigned long period)
+    void setPeriod_TIMER_TC3(float period)
     {
       TcCount16* _Timer = (TcCount16*) _SAMDTimer;
       
@@ -730,7 +730,7 @@ class SAMDTimerInterrupt
 	    
 	    while (_Timer->STATUS.bit.SYNCBUSY == 1);
 
-	    _compareValue = (int)(TIMER_HZ / (_prescaler / ((float)period / 1000000))) - 1;
+	    _compareValue = (int)(TIMER_HZ / (_prescaler / (period / 1000000.0))) - 1;
 
       
       // Make sure the count is in a proportional position to where it was
@@ -744,7 +744,7 @@ class SAMDTimerInterrupt
       TISR_LOGDEBUG1(F("_compareValue ="), _compareValue);
     }
     
-    void setPeriod_TIMER_TCC(unsigned long period)
+    void setPeriod_TIMER_TCC(float period)
     {
       Tcc* _Timer = (Tcc*) _SAMDTimer;
       
@@ -814,7 +814,7 @@ class SAMDTimerInterrupt
 		    _prescaler = 1;
 	    }
 	    
-	    _compareValue = (int)(TIMER_HZ / (_prescaler / ((float)period / 1000000))) - 1;
+	    _compareValue = (int)(TIMER_HZ / (_prescaler / (period / 1000000))) - 1;
 
 	    _Timer->PER.reg = _compareValue; 
 	    

--- a/src_cpp/SAMDTimerInterrupt.h
+++ b/src_cpp/SAMDTimerInterrupt.h
@@ -160,7 +160,7 @@ class SAMDTimerInterrupt
     timerCallback  _callback;        // pointer to the callback function
     float           _frequency;       // Timer frequency
     
-    unsigned long   _period;
+    float   _period;
     int             _prescaler;
     int             _compareValue;
 
@@ -186,7 +186,7 @@ class SAMDTimerInterrupt
     // No params and duration now. To be addes in the future by adding similar functions here or to SAMD-hal-timer.c
     bool setFrequency(float frequency, timerCallback callback)
     {
-      _period = (unsigned long) (1000000.0f / frequency);
+      _period =  (1000000.0f / frequency);
       
       if (_timerNumber == TIMER_TC3)
       {    
@@ -300,7 +300,7 @@ class SAMDTimerInterrupt
     
     private:
     
-    void setPeriod_TIMER_TC3(unsigned long period)
+    void setPeriod_TIMER_TC3(float period)
     {
       uint32_t TC_CTRLA_PRESCALER_DIVN;
 
@@ -364,7 +364,7 @@ class SAMDTimerInterrupt
       TC3->COUNT16.CTRLA.reg |= TC_CTRLA_PRESCALER_DIVN;
       TC3_wait_for_sync();
 
-      _compareValue = (int)(TIMER_HZ / (_prescaler/((float)period / 1000000))) - 1;
+      _compareValue = (int)(TIMER_HZ / (_prescaler/(period / 1000000.0))) - 1;
 
       // Make sure the count is in a proportional position to where it was
       // to prevent any jitter or disconnect when changing the compare value.
@@ -455,7 +455,7 @@ class SAMDTimerInterrupt
     float           _frequency;       // Timer frequency
     //uint32_t        _timerCount;      // count to activate timer
     
-    unsigned long   _period;
+    float   _period;
     int             _prescaler;
     int             _compareValue;
 
@@ -485,7 +485,7 @@ class SAMDTimerInterrupt
     // No params and duration now. To be addes in the future by adding similar functions here or to SAMD-hal-timer.c
     bool setFrequency(float frequency, timerCallback callback)
     {
-      _period = (unsigned long) (1000000.0f / frequency);
+      _period =  (1000000.0f / frequency);
       
       TISR_LOGDEBUG3(F("_period ="), _period, F(", frequency ="), frequency);
       
@@ -656,7 +656,7 @@ class SAMDTimerInterrupt
     
     private:
     
-    void setPeriod_TIMER_TC3(unsigned long period)
+    void setPeriod_TIMER_TC3(float period)
     {
       TcCount16* _Timer = (TcCount16*) _SAMDTimer;
       
@@ -730,7 +730,7 @@ class SAMDTimerInterrupt
 	    
 	    while (_Timer->STATUS.bit.SYNCBUSY == 1);
 
-	    _compareValue = (int)(TIMER_HZ / (_prescaler / ((float)period / 1000000))) - 1;
+	    _compareValue = (int)(TIMER_HZ / (_prescaler / (period / 1000000.0))) - 1;
 
       
       // Make sure the count is in a proportional position to where it was
@@ -744,7 +744,7 @@ class SAMDTimerInterrupt
       TISR_LOGDEBUG1(F("_compareValue ="), _compareValue);
     }
     
-    void setPeriod_TIMER_TCC(unsigned long period)
+    void setPeriod_TIMER_TCC(float period)
     {
       Tcc* _Timer = (Tcc*) _SAMDTimer;
       
@@ -814,7 +814,7 @@ class SAMDTimerInterrupt
 		    _prescaler = 1;
 	    }
 	    
-	    _compareValue = (int)(TIMER_HZ / (_prescaler / ((float)period / 1000000))) - 1;
+	    _compareValue = (int)(TIMER_HZ / (_prescaler / (period / 1000000.0))) - 1;
 
 	    _Timer->PER.reg = _compareValue; 
 	    

--- a/src_h/SAMDTimerInterrupt.h
+++ b/src_h/SAMDTimerInterrupt.h
@@ -160,7 +160,7 @@ class SAMDTimerInterrupt
     timerCallback  _callback;        // pointer to the callback function
     float           _frequency;       // Timer frequency
     
-    unsigned long   _period;
+    float   _period;
     int             _prescaler;
     int             _compareValue;
 
@@ -186,7 +186,7 @@ class SAMDTimerInterrupt
     // No params and duration now. To be addes in the future by adding similar functions here or to SAMD-hal-timer.c
     bool setFrequency(float frequency, timerCallback callback)
     {
-      _period = (unsigned long) (1000000.0f / frequency);
+      _period =  (1000000.0f / frequency);
       
       if (_timerNumber == TIMER_TC3)
       {    
@@ -300,7 +300,7 @@ class SAMDTimerInterrupt
     
     private:
     
-    void setPeriod_TIMER_TC3(unsigned long period)
+    void setPeriod_TIMER_TC3(float period)
     {
       uint32_t TC_CTRLA_PRESCALER_DIVN;
 
@@ -364,7 +364,7 @@ class SAMDTimerInterrupt
       TC3->COUNT16.CTRLA.reg |= TC_CTRLA_PRESCALER_DIVN;
       TC3_wait_for_sync();
 
-      _compareValue = (int)(TIMER_HZ / (_prescaler/((float)period / 1000000))) - 1;
+      _compareValue = (int)(TIMER_HZ / (_prescaler/(period / 1000000.0))) - 1;
 
       // Make sure the count is in a proportional position to where it was
       // to prevent any jitter or disconnect when changing the compare value.
@@ -455,7 +455,7 @@ class SAMDTimerInterrupt
     float           _frequency;       // Timer frequency
     //uint32_t        _timerCount;      // count to activate timer
     
-    unsigned long   _period;
+    float   _period;
     int             _prescaler;
     int             _compareValue;
 
@@ -485,7 +485,7 @@ class SAMDTimerInterrupt
     // No params and duration now. To be addes in the future by adding similar functions here or to SAMD-hal-timer.c
     bool setFrequency(float frequency, timerCallback callback)
     {
-      _period = (unsigned long) (1000000.0f / frequency);
+      _period =  (1000000.0f / frequency);
       
       TISR_LOGDEBUG3(F("_period ="), _period, F(", frequency ="), frequency);
       
@@ -656,7 +656,7 @@ class SAMDTimerInterrupt
     
     private:
     
-    void setPeriod_TIMER_TC3(unsigned long period)
+    void setPeriod_TIMER_TC3(float period)
     {
       TcCount16* _Timer = (TcCount16*) _SAMDTimer;
       
@@ -730,7 +730,7 @@ class SAMDTimerInterrupt
 	    
 	    while (_Timer->STATUS.bit.SYNCBUSY == 1);
 
-	    _compareValue = (int)(TIMER_HZ / (_prescaler / ((float)period / 1000000))) - 1;
+	    _compareValue = (int)(TIMER_HZ / (_prescaler / (period / 1000000.0))) - 1;
 
       
       // Make sure the count is in a proportional position to where it was
@@ -744,7 +744,7 @@ class SAMDTimerInterrupt
       TISR_LOGDEBUG1(F("_compareValue ="), _compareValue);
     }
     
-    void setPeriod_TIMER_TCC(unsigned long period)
+    void setPeriod_TIMER_TCC(float period)
     {
       Tcc* _Timer = (Tcc*) _SAMDTimer;
       
@@ -814,7 +814,7 @@ class SAMDTimerInterrupt
 		    _prescaler = 1;
 	    }
 	    
-	    _compareValue = (int)(TIMER_HZ / (_prescaler / ((float)period / 1000000))) - 1;
+	    _compareValue = (int)(TIMER_HZ / (_prescaler / (period / 1000000.0))) - 1;
 
 	    _Timer->PER.reg = _compareValue; 
 	    


### PR DESCRIPTION
In my application I need interrupt frequencies of 12000 Hz and 12050 Hz. With the current library this was not possible because both values led to the same interrupt frequency.
My solution is to change the variable period from unsigned long to float. This gives more resolution at high interrupt frequencies.

Unfortunately I don't know if this affects other functions...

Could you please have a look on this.